### PR TITLE
Restrict permissions to user

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -39,7 +39,7 @@ class znc::config(
   File {
     owner => $znc::params::zc_user,
     group => $znc::params::zc_group,
-    mode  => '0644',
+    mode  => '0600',
   }
   Exec {
     path => '/bin:/sbin:/usr/bin:/usr/sbin'


### PR DESCRIPTION
While in the manifest we specify 0644 as the permissions for
`/etc/znc/config/znc.conf`, the ZNC daemon automatically resets them to 0600.
This causes that on every `puppet apply` the file mode is changed to the
specified value causing the ZNC server to be restarted and the file mode to be
reset again to what ZNC wants.

This commit sets the default permissions for every config file to 0600, such
that they remain readable only by the ZNC server.
