### PR TITLE
Update RH family package names.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,7 +23,7 @@ class znc::params {
   case $::operatingsystem {
     redhat,fedora,centos: {
       $zc_suffix = 'redhat'
-      $zc_packages = ['znc', 'znc-extra']
+      $zc_packages = ['znc', 'znc-modtcl', 'znc-modperl']
     }
     ubuntu, debian: {
       $zc_suffix = 'debian'


### PR DESCRIPTION
As of version 1.0 of ZNC-extra is gone (http://wiki.znc.in/ZNC-Extra)  RH family seems to have tcl and perl packages now too, except EL5 doesn't have the perl one. I left it in the list because this wouldn't have worked on EL5 the way it was regardless.

In newer fedora there is also znc-modpython, but i didn't try adding that either.