### PR TITLE
manage systemd for debian 8 and el7

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,3 +42,4 @@ Simple Usage:
 Puppet Labs Standard Library
 - http://github.com/puppetlabs/puppetlabs-stdlib
 - znc (1.4) (new version can be used from https://launchpad.net/~teward/+archive/ubuntu/znc)
+- if running on OS using systemd, you'll also need [puppet-systemd](http://github.com/camptocamp/puppet-systemd)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,6 +41,7 @@ class znc::config (
   $global_modules      = undef,
   $motd                = undef,
   $ipv6                = undef,
+  $systemd             = udnef,
   $port                = undef,) {
   File {
     owner => $::znc::params::zc_user,
@@ -96,6 +97,16 @@ class znc::config (
     group   => 'root',
     mode    => '0755',
     content => template("znc/etc/init.d/znc.${::znc::params::zc_suffix}.erb"),
+  }
+  if $systemd {
+    include ::systemd
+    file { '/lib/systemd/system/znc.service':
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      content => template('znc/systemd/znc.service.erb'),
+    } ~> Exec['systemctl-daemon-reload']
   }
 
   # Bootstrap SSL

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,7 @@ class znc(
   $global_modules      = undef,
   $ipv6                = $::znc::params::zc_ipv6,
   $port                = $::znc::params::zc_port,
+  $systemd             = $::znc::params::systemd,
 
   $znc_admin_user      = undef,
   $znc_admin_pass      = undef,
@@ -86,6 +87,7 @@ class znc(
       motd                => $motd,
       ipv6                => $ipv6,
       port                => $port,
+      systemd             => $systemd,
     }
       # we need to define at least one user in order to start service
   -> ::znc::user { $znc_admin_user :

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,10 +24,26 @@ class znc::params {
     redhat,fedora,centos: {
       $zc_suffix = 'redhat'
       $zc_packages = ['znc', 'znc-modtcl', 'znc-modperl']
+      case $::operatingsystemmajrelease {
+        7: {
+          $systemd = true
+        }
+        default: {
+          $systemd = false
+        }
+      }
     }
     ubuntu, debian: {
       $zc_suffix = 'debian'
       $zc_packages = [ 'znc', 'znc-tcl', 'znc-perl' ]
+      case $::operatingsystemmajrelease {
+        8: {
+          $systemd = true
+        }
+        default: {
+          $systemd = true
+        }
+      }
     }
     default: {
       fail("Module ${module_name} is not supported on ${::operatingsystem}")

--- a/templates/systemd/znc.service.erb
+++ b/templates/systemd/znc.service.erb
@@ -1,0 +1,12 @@
+[Unit]
+Description=ZNC - an advanced IRC bouncer
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/znc -d /etc/znc
+User=<%= scope.lookupvar('znc::params::zc_user') %>
+Type=forking
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Under these os versions, the module fails because the generated unit file does not use `-d /etc/znc`
as `ExecStart` parameters.