### PR TITLE
Commit to close issue #16 for network name option

### DIFF
--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -30,7 +30,8 @@ define znc::user (
   $ssl             = false,
   $quitmsg         = 'quit',
   $pass            = '',
-  $channels        = undef,) {
+  $channels        = undef,
+  $network         = undef,) {
   if ! defined(Class['znc']) {
     fail('You must include znc base class before using any user defined resources')
   }

--- a/templates/configs/znc.conf.seed.erb
+++ b/templates/configs/znc.conf.seed.erb
@@ -23,7 +23,11 @@
 
 
         <% if ! @admin %>
+        <% if @network %>
+        <Network <%= @network %>>
+        <% else %>
         <Network freenode>
+        <% end %>
                 FloodBurst = 4
                 FloodRate = 1.00
                 IRCConnectEnabled = true


### PR DESCRIPTION
If left undefined the default is still freenode.

Fixes: #16 