### PR TITLE
Make global MaxBufferSize configurable

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@
 #  been deployed
 #
 # Parameters:
+#   $max_buffer_size: Global line limit for playback buffer size per channel.
 #   $auth_type: (plain|sasl). Will determine to use local auth or SASL auth.
 #   $ssl: (true|false). To enable or disable SSL support. Will autogen a SSL certificate.
 #   $port: port to run ZNC on.
@@ -29,6 +30,7 @@
 # Sample Usage:
 #  This module should not be called directly.
 class znc::config (
+  $max_buffer_size,
   $auth_type           = undef,
   $ssl                 = undef,
   $ssl_source          = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,7 @@ class znc(
   $ipv6                = $::znc::params::zc_ipv6,
   $port                = $::znc::params::zc_port,
   $systemd             = $::znc::params::systemd,
+  $max_buffer_size     = $::znc::params::max_buffer_size,
 
   $znc_admin_user      = undef,
   $znc_admin_pass      = undef,
@@ -88,6 +89,7 @@ class znc(
       ipv6                => $ipv6,
       port                => $port,
       systemd             => $systemd,
+      max_buffer_size     => $max_buffer_size,
     }
       # we need to define at least one user in order to start service
   -> ::znc::user { $znc_admin_user :

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,6 +50,8 @@ class znc::params {
     }
   }
 
+  $max_buffer_size = 500
+
 # server definition
   $zc_user       = 'znc'
   $zc_group      = 'znc'

--- a/templates/configs/znc.conf.header.erb
+++ b/templates/configs/znc.conf.header.erb
@@ -18,7 +18,7 @@ LoadModule = <%= global_module %>
 <% if @auth_type == 'sasl' -%>
 LoadModule = saslauth saslauthd
 <% end -%>
-MaxBufferSize = 500
+MaxBufferSize = <%= @max_buffer_size %>
 <% if @motd -%>
 Motd = <%= @motd %>
 <% end -%>


### PR DESCRIPTION
The default of 500 lines is too conservative and almost never what you
want, especially if you set it up for personal use.